### PR TITLE
builder: make Option methods more ergonomic

### DIFF
--- a/examples/device_mini_example.rs
+++ b/examples/device_mini_example.rs
@@ -209,15 +209,15 @@ fn make_device_description(
 
     // Build the device description
     let desc = DeviceDescriptionBuilder::new()
-        .name(Some("homie5client test-device-1".to_owned()))
+        .name("homie5client test-device-1")
         .add_node(
             light_node.id.clone(),
             NodeDescriptionBuilder::new()
-                .name(Some("Light node".to_owned()))
+                .name("Light node")
                 .add_property(
                     prop_light_state.id.clone(),
                     PropertyDescriptionBuilder::new(HomieDataType::Boolean)
-                        .name(Some("Light state".to_owned()))
+                        .name("Light state")
                         .format(HomiePropertyFormat::Boolean {
                             false_val: "off".to_string(),
                             true_val: "on".to_string(),
@@ -228,13 +228,13 @@ fn make_device_description(
                 .add_property(
                     prop_light_brightness.id.clone(),
                     PropertyDescriptionBuilder::new(HomieDataType::Integer)
-                        .name(Some("Brightness".to_owned()))
+                        .name("Brightness")
                         .format(HomiePropertyFormat::IntegerRange(IntegerRange {
                             min: Some(0),
                             max: Some(100),
                             step: None,
                         }))
-                        .unit(Some(HOMIE_UNIT_PERCENT.to_string()))
+                        .unit(HOMIE_UNIT_PERCENT)
                         .settable(true)
                         .build(),
                 )

--- a/examples/devices/light_device.rs
+++ b/examples/devices/light_device.rs
@@ -52,15 +52,15 @@ impl LightDevice {
 
         // Build the device description
         let desc = DeviceDescriptionBuilder::new()
-            .name(Some("homie5client test-device-1".to_owned()))
+            .name("homie5client test-device-1")
             .add_node(
                 light_node.id.clone(),
                 NodeDescriptionBuilder::new()
-                    .name(Some("Light node".to_owned()))
+                    .name("Light node")
                     .add_property(
                         prop_light_state.id.clone(),
                         PropertyDescriptionBuilder::new(HomieDataType::Boolean)
-                            .name(Some("Light state".to_owned()))
+                            .name("Light state")
                             .format(HomiePropertyFormat::Boolean {
                                 false_val: "off".to_string(),
                                 true_val: "on".to_string(),
@@ -72,13 +72,13 @@ impl LightDevice {
                     .add_property(
                         prop_light_brightness.id.clone(),
                         PropertyDescriptionBuilder::new(HomieDataType::Integer)
-                            .name(Some("Brightness".to_owned()))
+                            .name("Brightness")
                             .format(HomiePropertyFormat::IntegerRange(IntegerRange {
                                 min: Some(0),
                                 max: Some(100),
                                 step: None,
                             }))
-                            .unit(Some(HOMIE_UNIT_PERCENT.to_string()))
+                            .unit(HOMIE_UNIT_PERCENT)
                             .retained(true)
                             .settable(true)
                             .build(),
@@ -87,9 +87,7 @@ impl LightDevice {
             )
             .add_node(
                 "node-2".try_into().unwrap(),
-                NodeDescriptionBuilder::new()
-                    .name(Some("Second Node - no props".to_owned()))
-                    .build(),
+                NodeDescriptionBuilder::new().name("Second Node - no props").build(),
             )
             .build();
         (desc, light_node, prop_light_state, prop_light_brightness)

--- a/src/device_description/builder.rs
+++ b/src/device_description/builder.rs
@@ -27,7 +27,7 @@ use std::collections::{hash_map, HashMap};
 /// ```rust
 /// use homie5::device_description::*;
 /// let device_description = DeviceDescriptionBuilder::new()
-///     .name(Some("MyDevice".to_string()))
+///     .name("MyDevice")
 ///     .add_child("node1".try_into().unwrap())
 ///     .add_extension("com.example.extension".to_string())
 ///     .build();
@@ -91,18 +91,18 @@ impl DeviceDescriptionBuilder {
         self
     }
 
-    pub fn parent(mut self, parent: Option<HomieID>) -> Self {
-        self.description.parent = parent;
+    pub fn parent(mut self, parent: impl Into<Option<HomieID>>) -> Self {
+        self.description.parent = parent.into();
         self
     }
 
-    pub fn root(mut self, parent: Option<HomieID>) -> Self {
-        self.description.root = parent;
+    pub fn root(mut self, parent: impl Into<Option<HomieID>>) -> Self {
+        self.description.root = parent.into();
         self
     }
 
-    pub fn name(mut self, name: Option<String>) -> Self {
-        self.description.name = name;
+    pub fn name<S: Into<String>>(mut self, name: impl Into<Option<S>>) -> Self {
+        self.description.name = name.into().map(Into::into);
         self
     }
 

--- a/src/device_description/builder.rs
+++ b/src/device_description/builder.rs
@@ -155,7 +155,7 @@ impl DeviceDescriptionBuilder {
 /// ```rust
 /// use homie5::device_description::*;
 /// let node_description = NodeDescriptionBuilder::new()
-///     .name(Some("TemperatureNode".to_string()))
+///     .name("TemperatureNode")
 ///     .r#type("sensor")
 ///     .build();
 /// ```
@@ -190,8 +190,8 @@ impl NodeDescriptionBuilder {
         self.description
     }
 
-    pub fn name(mut self, name: Option<String>) -> Self {
-        self.description.name = name;
+    pub fn name<S: Into<String>>(mut self, name: impl Into<Option<S>>) -> Self {
+        self.description.name = name.into().map(Into::into);
         self
     }
 
@@ -264,10 +264,10 @@ impl NodeDescriptionBuilder {
 /// use homie5::device_description::*;
 /// use homie5::*;
 /// let property_description = PropertyDescriptionBuilder::new(HomieDataType::Float)
-///     .name(Some("Temperature".to_string()))
+///     .name("Temperature")
 ///     .settable(false)
 ///     .retained(true)
-///     .unit(Some("°C".to_string()))
+///     .unit(HOMIE_UNIT_DEGREE_CELSIUS)
 ///     .build();
 /// ```
 pub struct PropertyDescriptionBuilder {
@@ -310,8 +310,8 @@ impl PropertyDescriptionBuilder {
         self
     }
 
-    pub fn name(mut self, name: Option<String>) -> Self {
-        self.description.name = name;
+    pub fn name<S: Into<String>>(mut self, name: impl Into<Option<S>>) -> Self {
+        self.description.name = name.into().map(Into::into);
         self
     }
 
@@ -325,8 +325,8 @@ impl PropertyDescriptionBuilder {
         self
     }
 
-    pub fn unit(mut self, unit: Option<String>) -> Self {
-        self.description.unit = unit;
+    pub fn unit<S: Into<String>>(mut self, unit: impl Into<Option<S>>) -> Self {
+        self.description.unit = unit.into().map(Into::into);
         self
     }
 

--- a/src/device_description/builder.rs
+++ b/src/device_description/builder.rs
@@ -311,7 +311,7 @@ impl PropertyDescriptionBuilder {
     }
 
     pub fn name<S: Into<String>>(mut self, name: impl Into<Option<S>>) -> Self {
-        self.description.name = name.into().map(Into::into);
+        self.description.name = name.into().map(|s| s.into());
         self
     }
 

--- a/tests/homie_value.rs
+++ b/tests/homie_value.rs
@@ -342,7 +342,7 @@ fn test_integer_value_with_step_rounding_2() {
 #[test]
 fn test_integer_ok() {
     let desc = PropertyDescriptionBuilder::new(HomieDataType::Integer)
-        .name(Some("test".to_owned()))
+        .name("test")
         .build();
     assert!(matches!(HomieValue::parse("122", &desc), Ok(HomieValue::Integer(122))));
 }
@@ -350,7 +350,7 @@ fn test_integer_ok() {
 #[test]
 fn test_integer_nok() {
     let desc = PropertyDescriptionBuilder::new(HomieDataType::Integer)
-        .name(Some("test".to_owned()))
+        .name("test")
         .build();
     assert!(matches!(
         HomieValue::parse("bla2", &desc),


### PR DESCRIPTION
Device name in particular can now be supplied as a plain string literal, but I also went through the other option-taking methods and made them into `Into<Option<_>>` too.