### PR TITLE
builder/description: use BTreeMap instead of hashmap for KVs

### DIFF
--- a/src/device_description/builder.rs
+++ b/src/device_description/builder.rs
@@ -9,13 +9,12 @@
 //! based on runtime conditions.
 //!
 //! ```
-use crate::{HomieDataType, HomieID, HOMIE_VERSION_FULL};
-
+use super::property_format::HomiePropertyFormat;
 use super::{
-    property_format::HomiePropertyFormat, HomieDeviceDescription, HomieNodeDescription, HomiePropertyDescription,
-    RETAINTED_DEFAULT, SETTABLE_DEFAULT,
+    HomieDeviceDescription, HomieNodeDescription, HomiePropertyDescription, RETAINTED_DEFAULT, SETTABLE_DEFAULT,
 };
-use std::collections::{hash_map, HashMap};
+use crate::{HomieDataType, HomieID, HOMIE_VERSION_FULL};
+use std::collections::{BTreeMap, btree_map};
 
 /// Builder for constructing `HomieDeviceDescription` objects.
 ///
@@ -45,7 +44,7 @@ impl Default for DeviceDescriptionBuilder {
                 homie: HOMIE_VERSION_FULL.to_owned(),
                 children: Vec::new(),
                 extensions: Vec::new(),
-                nodes: HashMap::new(),
+                nodes: BTreeMap::new(),
                 parent: None,
                 root: None,
             },
@@ -131,12 +130,12 @@ impl DeviceDescriptionBuilder {
     ) -> Self {
         let entry = self.description.nodes.entry(node_id);
         match entry {
-            hash_map::Entry::Occupied(mut oe) => {
+            btree_map::Entry::Occupied(mut oe) => {
                 let oe_mut = oe.get_mut();
                 let new_desc = f(Some(oe_mut));
                 *oe_mut = new_desc;
             }
-            hash_map::Entry::Vacant(ve) => {
+            btree_map::Entry::Vacant(ve) => {
                 let new_desc = f(None);
                 ve.insert(new_desc);
             }
@@ -169,7 +168,7 @@ impl Default for NodeDescriptionBuilder {
             description: HomieNodeDescription {
                 name: None,
                 r#type: None,
-                properties: HashMap::new(),
+                properties: BTreeMap::new(),
             },
         }
     }
@@ -238,12 +237,12 @@ impl NodeDescriptionBuilder {
     ) -> Self {
         let entry = self.description.properties.entry(prop_id);
         match entry {
-            hash_map::Entry::Occupied(mut oe) => {
+            btree_map::Entry::Occupied(mut oe) => {
                 let oe_mut = oe.get_mut();
                 let new_desc = f(Some(oe_mut));
                 *oe_mut = new_desc;
             }
-            hash_map::Entry::Vacant(ve) => {
+            btree_map::Entry::Vacant(ve) => {
                 let new_desc = f(None);
                 ve.insert(new_desc);
             }

--- a/src/device_description/mod.rs
+++ b/src/device_description/mod.rs
@@ -1,9 +1,10 @@
 //! This module provides all types and tools to create (builders) and manage homie device, node and property
 //! descriptions.
 use std::collections::hash_map::DefaultHasher;
+use std::collections::BTreeMap;
+use std::hash::Hash;
 use std::hash::Hasher;
 use std::iter::Iterator;
-use std::{collections::HashMap, hash::Hash};
 
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -159,7 +160,7 @@ pub struct HomieNodeDescription {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
     #[serde(default, skip_serializing_if = "serde_skip_if_properties")]
-    pub properties: HashMap<HomieID, HomiePropertyDescription>,
+    pub properties: BTreeMap<HomieID, HomiePropertyDescription>,
 }
 impl HomieNodeDescription {
     pub fn with_property<T>(
@@ -207,11 +208,11 @@ where
 }
 
 /// If the properties HashMap is empty, skip serializing the field
-fn serde_skip_if_properties(properties: &HashMap<HomieID, HomiePropertyDescription>) -> bool {
+fn serde_skip_if_properties(properties: &BTreeMap<HomieID, HomiePropertyDescription>) -> bool {
     properties.is_empty()
 }
 
-pub type HomieNodes = HashMap<HomieID, HomieNodeDescription>;
+pub type HomieNodes = BTreeMap<HomieID, HomieNodeDescription>;
 /// HomieDeviceDescription
 ///
 /// The JSON description document has the following format:
@@ -271,7 +272,7 @@ impl Default for HomieDeviceDescription {
             root: None,
             parent: None,
             extensions: Vec::new(),
-            nodes: HashMap::new(),
+            nodes: BTreeMap::new(),
         }
     }
 }
@@ -381,7 +382,7 @@ impl Hash for HomieDeviceDescription {
 }
 
 /// If the nodes HashMap is empty, skip serializing the field
-fn serde_skip_if_nodes(nodes: &HashMap<HomieID, HomieNodeDescription>) -> bool {
+fn serde_skip_if_nodes(nodes: &BTreeMap<HomieID, HomieNodeDescription>) -> bool {
     nodes.is_empty()
 }
 
@@ -395,9 +396,9 @@ fn serde_skip_if_empty_list<T>(children: &[T]) -> bool {
 
 pub struct HomiePropertyIterator<'a> {
     _device: &'a HomieDeviceDescription,
-    node_iter: std::collections::hash_map::Iter<'a, HomieID, HomieNodeDescription>,
+    node_iter: std::collections::btree_map::Iter<'a, HomieID, HomieNodeDescription>,
     current_node: Option<(&'a HomieID, &'a HomieNodeDescription)>,
-    property_iter: Option<std::collections::hash_map::Iter<'a, HomieID, HomiePropertyDescription>>,
+    property_iter: Option<std::collections::btree_map::Iter<'a, HomieID, HomiePropertyDescription>>,
 }
 
 impl<'a> HomiePropertyIterator<'a> {


### PR DESCRIPTION
BTreeMap naturally sorts the elements by key, which results in a device description json that remains static run-to-run and easier to scan by eye compared to the random ordering that HashMap introduces.

(If my experience is anything to go by, it is also most probably is going to be slightly faster in general case where map keys don't share super long common prefixes, but I haven't produced any benchmarks to that effect here and I doubt performance in this area is super critical anyhow, given the number of allocations happening.)