### PR TITLE
fixed float and interger range rounding beheviour according to homie conventions specification

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -57,7 +57,7 @@ impl fmt::Display for Homie5ValueConversionError {
                 write!(f, "Integer '{}' is out of allowed range: {}", value, range)
             }
             Homie5ValueConversionError::FloatOutOfRange(value, range) => {
-                write!(f, "Flaot '{}' is out of allowed range: {}", value, range)
+                write!(f, "Float '{}' is out of allowed range: {}", value, range)
             }
             Homie5ValueConversionError::InvalidDateTimeFormat(value) => {
                 write!(f, "'{}' is not a valid date/time value", value)
@@ -188,7 +188,7 @@ impl Display for HomieColorValue {
 impl FromStr for HomieColorValue {
     type Err = Homie5ValueConversionError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut tokens = str::split(s, ',');
+        let mut tokens = s.split(',');
         match tokens.next() {
             Some("rgb") => {
                 if let (Some(Ok(r)), Some(Ok(g)), Some(Ok(b))) = (
@@ -620,12 +620,13 @@ impl HomieValue {
         let HomiePropertyFormat::FloatRange(range) = &property_desc.format else {
             return Ok(value);
         };
-        // Use the minimum, max, or current value as base (in that priority order)
+
+        // Use min as base, if not present, use max, otherwise use the current value
         let base = range.min.or(range.max).unwrap_or(value);
 
-        // Calculate the rounded value based on the step
+        // Adjust rounding logic: floor((x + 0.5)) to always round up
         let rounded = match range.step {
-            Some(s) if s > 0.0 => ((value - base) / s).round() * s + base,
+            Some(s) if s > 0.0 => ((value - base) / s + 0.5).floor() * s + base,
             _ => value,
         };
 
@@ -642,12 +643,12 @@ impl HomieValue {
             return Ok(value);
         };
 
-        // Use the minimum or maximum as the base, or use the current value
+        // Use min as base, if not present, use max, otherwise use the current value
         let base = range.min.or(range.max).unwrap_or(value);
 
-        // Calculate the rounded value based on the step
+        // Adjust rounding logic: floor((x + 0.5)) to always round up
         let rounded = match range.step {
-            Some(s) if s > 0 => ((value - base) as f64 / s as f64).round() as i64 * s + base,
+            Some(s) if s > 0 => ((value - base) as f64 / s as f64 + 0.5).floor() as i64 * s + base,
             _ => value,
         };
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -77,6 +77,7 @@ pub enum HomieTest {
     PropertyDescription(HomieTestDefinition<serde_yaml::Value, Option<()>, Option<()>>),
     PropertyValue(HomieTestDefinition<HomiePropertyDescription, String, Option<()>>),
     PropertyValueInteger(HomieTestDefinition<HomiePropertyDescription, String, Option<i64>>),
+    PropertyValueFloat(HomieTestDefinition<HomiePropertyDescription, String, Option<f64>>),
     HomieID(HomieTestDefinition<Option<()>, String, Option<()>>),
 }
 
@@ -88,6 +89,7 @@ impl HomieTest {
             HomieTest::PropertyValue(homie_test_definition) => &homie_test_definition.description,
             HomieTest::PropertyValueInteger(homie_test_definition) => &homie_test_definition.description,
             HomieTest::HomieID(homie_test_definition) => &homie_test_definition.description,
+            HomieTest::PropertyValueFloat(homie_test_definition) => &homie_test_definition.description,
         }
     }
     pub fn valid(&self) -> bool {
@@ -95,6 +97,7 @@ impl HomieTest {
             HomieTest::PropertyDescription(homie_test_definition) => homie_test_definition.valid,
             HomieTest::PropertyValue(homie_test_definition) => homie_test_definition.valid,
             HomieTest::PropertyValueInteger(homie_test_definition) => homie_test_definition.valid,
+            HomieTest::PropertyValueFloat(homie_test_definition) => homie_test_definition.valid,
             HomieTest::HomieID(homie_test_definition) => homie_test_definition.valid,
         }
     }

--- a/tests/homie_value.rs
+++ b/tests/homie_value.rs
@@ -40,6 +40,24 @@ fn test_homie_integer_value_from_file() {
 }
 
 #[test]
+fn test_homie_float_value_from_file() {
+    let result = run_homietests("homie5/values/float.yml", |test_definition| {
+        if let HomieTest::PropertyValueFloat(test) = test_definition {
+            let Ok(homie_value) = HomieValue::parse(&test.input_data, &test.definition) else {
+                return Ok(false);
+            };
+            let HomieValue::Float(value) = homie_value else {
+                return Err(anyhow::anyhow!("Invalid Testdefinition in test file"));
+            };
+            Ok(Some(value) == test.output_data)
+        } else {
+            Err(anyhow::anyhow!("Invalid Testdefinition in test file"))
+        }
+    });
+
+    assert!(result.is_ok(), "{:?}", result);
+}
+#[test]
 fn test_homie_color_value_display_rgb() {
     let color = HomieColorValue::RGB(255, 100, 50);
     assert_eq!(color.to_string(), "rgb,255,100,50");
@@ -284,7 +302,7 @@ fn test_integer_value_with_max_only_range() {
     assert_eq!(HomieValue::parse("8", &desc).unwrap(), HomieValue::Integer(8));
 
     // Value rounded to nearest step
-    assert_eq!(HomieValue::parse("9", &desc).unwrap(), HomieValue::Integer(8));
+    assert_eq!(HomieValue::parse("9", &desc).unwrap(), HomieValue::Integer(10));
 
     // Value too high (out of range)
     assert!(HomieValue::parse("21", &desc).is_err());


### PR DESCRIPTION
Up to now the implementation for the float and integer range rounding has not been up to specification.
See https://github.com/homieiot/convention/issues/301 and  https://github.com/homieiot/convention/pull/313
