### PR TITLE
impl FromStr for HomieID

### DIFF
--- a/src/homie_id.rs
+++ b/src/homie_id.rs
@@ -182,6 +182,14 @@ impl TryFrom<String> for HomieID {
     }
 }
 
+impl std::str::FromStr for HomieID {
+    type Err = InvalidHomieIDError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        <String as TryInto<Self>>::try_into(s.to_string())
+    }
+}
+
 impl fmt::Display for HomieID {
     /// Formats the `HomieID` as a string for display purposes.
     ///


### PR DESCRIPTION
This is useful when HomieID is used as a clap argument (clap is able to handle `from_str` arguments ~transparently) which is possibly a common use-case to allow user-configurable device IDs.