### PR TITLE
improve ergonomics of integer, float, color and boolean formats slightly

### DIFF
--- a/src/device_description/builder.rs
+++ b/src/device_description/builder.rs
@@ -304,8 +304,8 @@ impl PropertyDescriptionBuilder {
         self.description
     }
 
-    pub fn format(mut self, format: HomiePropertyFormat) -> Self {
-        self.description.format = format;
+    pub fn format<F: Into<HomiePropertyFormat>>(mut self, format: F) -> Self {
+        self.description.format = format.into();
         self
     }
 

--- a/src/device_description/property_format.rs
+++ b/src/device_description/property_format.rs
@@ -1,7 +1,8 @@
-use std::fmt::Display;
 use std::hash::Hash;
 use std::iter::Iterator;
+use std::ops::{RangeFrom, RangeTo};
 use std::str::FromStr;
+use std::{fmt::Display, ops::RangeInclusive};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -181,5 +182,95 @@ impl HomiePropertyFormat {
             // string data
             _ => Ok(Self::Custom(raw.to_owned())),
         }
+    }
+}
+
+impl From<FloatRange> for HomiePropertyFormat {
+    fn from(value: FloatRange) -> Self {
+        HomiePropertyFormat::FloatRange(value)
+    }
+}
+
+impl From<RangeInclusive<f64>> for HomiePropertyFormat {
+    fn from(value: RangeInclusive<f64>) -> Self {
+        HomiePropertyFormat::FloatRange(FloatRange {
+            min: Some(*value.start()),
+            max: Some(*value.end()),
+            step: None,
+        })
+    }
+}
+
+impl From<RangeTo<f64>> for HomiePropertyFormat {
+    fn from(value: RangeTo<f64>) -> Self {
+        HomiePropertyFormat::FloatRange(FloatRange {
+            min: None,
+            max: Some(value.end),
+            step: None,
+        })
+    }
+}
+
+impl From<RangeFrom<f64>> for HomiePropertyFormat {
+    fn from(value: RangeFrom<f64>) -> Self {
+        HomiePropertyFormat::FloatRange(FloatRange {
+            min: Some(value.start),
+            max: None,
+            step: None,
+        })
+    }
+}
+
+impl From<IntegerRange> for HomiePropertyFormat {
+    fn from(value: IntegerRange) -> Self {
+        HomiePropertyFormat::IntegerRange(value)
+    }
+}
+
+impl From<RangeInclusive<i64>> for HomiePropertyFormat {
+    fn from(value: RangeInclusive<i64>) -> Self {
+        HomiePropertyFormat::IntegerRange(IntegerRange {
+            min: Some(*value.start()),
+            max: Some(*value.end()),
+            step: None,
+        })
+    }
+}
+
+impl From<RangeTo<i64>> for HomiePropertyFormat {
+    fn from(value: RangeTo<i64>) -> Self {
+        HomiePropertyFormat::IntegerRange(IntegerRange {
+            min: None,
+            max: Some(value.end),
+            step: None,
+        })
+    }
+}
+
+impl From<RangeFrom<i64>> for HomiePropertyFormat {
+    fn from(value: RangeFrom<i64>) -> Self {
+        HomiePropertyFormat::IntegerRange(IntegerRange {
+            min: Some(value.start),
+            max: None,
+            step: None,
+        })
+    }
+}
+
+impl From<BooleanFormat> for HomiePropertyFormat {
+    fn from(value: BooleanFormat) -> Self {
+        HomiePropertyFormat::Boolean(value)
+    }
+}
+
+impl From<&[ColorFormat]> for HomiePropertyFormat {
+    fn from(value: &[ColorFormat]) -> Self {
+        HomiePropertyFormat::Color(value.to_vec())
+    }
+}
+
+impl From<Vec<ColorFormat>> for HomiePropertyFormat {
+    fn from(value: Vec<ColorFormat>) -> Self {
+        HomiePropertyFormat::Color(value)
     }
 }

--- a/src/homie_id.rs
+++ b/src/homie_id.rs
@@ -182,6 +182,14 @@ impl TryFrom<String> for HomieID {
     }
 }
 
+impl std::str::FromStr for HomieID {
+    type Err = InvalidHomieIDError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        <String as TryInto<Self>>::try_into(s.to_string())
+    }
+}
+
 impl fmt::Display for HomieID {
     /// Formats the `HomieID` as a string for display purposes.
     ///


### PR DESCRIPTION
I find it quite annoying to keep building the home descriptions and one
of the more annoying things I find is describing properties. This change
improves the situation slightly by making it quite a bit more
straightforward to describe common integer, float and boolean formats.
In particular now instead of having to write out the entire
`HomePropertyFormat::SomeType(SomeType { ... })`, `IntegerRange`, `FloatRange`,
`BooleanFormat` etc can be passed in as an argument directly. For
integers and floats a further ergonomics are achieved by allowing another 
common case (range without step) to be provided by using Rust's
built-in ranges.

For color format it might make sense to explore making it a bitfield
rather than a vector of enums. Among other things it would enforce that
the same colour does not appear twice. But even if that's done in the
future these From implementations would still be implementable just
fine, so they seemed fine to add.

The only caveat is that this likely has a negative impact on diagnostics.