### PR TITLE
move from impls converting from ranges to {Integer,Float}Range

### DIFF
--- a/src/device_description/number_ranges.rs
+++ b/src/device_description/number_ranges.rs
@@ -1,5 +1,6 @@
-use std::fmt::Display;
 use std::hash::Hash;
+use std::ops::{RangeFrom, RangeTo};
+use std::{fmt::Display, ops::RangeInclusive};
 
 use serde::{Deserialize, Serialize};
 
@@ -127,6 +128,36 @@ impl Display for FloatRange {
     }
 }
 
+impl From<RangeInclusive<f64>> for FloatRange {
+    fn from(value: RangeInclusive<f64>) -> Self {
+        FloatRange {
+            min: Some(*value.start()),
+            max: Some(*value.end()),
+            step: None,
+        }
+    }
+}
+
+impl From<RangeTo<f64>> for FloatRange {
+    fn from(value: RangeTo<f64>) -> Self {
+        FloatRange {
+            min: None,
+            max: Some(value.end),
+            step: None,
+        }
+    }
+}
+
+impl From<RangeFrom<f64>> for FloatRange {
+    fn from(value: RangeFrom<f64>) -> Self {
+        FloatRange {
+            min: Some(value.start),
+            max: None,
+            step: None,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Hash, PartialEq, PartialOrd)]
 pub struct IntegerRange {
     pub min: Option<i64>,
@@ -226,5 +257,35 @@ impl Display for IntegerRange {
             write!(f, ":{}", step)?;
         }
         Ok(())
+    }
+}
+
+impl From<RangeInclusive<i64>> for IntegerRange {
+    fn from(value: RangeInclusive<i64>) -> Self {
+        IntegerRange {
+            min: Some(*value.start()),
+            max: Some(*value.end()),
+            step: None,
+        }
+    }
+}
+
+impl From<RangeTo<i64>> for IntegerRange {
+    fn from(value: RangeTo<i64>) -> Self {
+        IntegerRange {
+            min: None,
+            max: Some(value.end),
+            step: None,
+        }
+    }
+}
+
+impl From<RangeFrom<i64>> for IntegerRange {
+    fn from(value: RangeFrom<i64>) -> Self {
+        IntegerRange {
+            min: Some(value.start),
+            max: None,
+            step: None,
+        }
     }
 }

--- a/src/device_description/property_format.rs
+++ b/src/device_description/property_format.rs
@@ -1,8 +1,7 @@
+use std::fmt::Display;
 use std::hash::Hash;
 use std::iter::Iterator;
-use std::ops::{RangeFrom, RangeTo};
 use std::str::FromStr;
-use std::{fmt::Display, ops::RangeInclusive};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -191,69 +190,9 @@ impl From<FloatRange> for HomiePropertyFormat {
     }
 }
 
-impl From<RangeInclusive<f64>> for HomiePropertyFormat {
-    fn from(value: RangeInclusive<f64>) -> Self {
-        HomiePropertyFormat::FloatRange(FloatRange {
-            min: Some(*value.start()),
-            max: Some(*value.end()),
-            step: None,
-        })
-    }
-}
-
-impl From<RangeTo<f64>> for HomiePropertyFormat {
-    fn from(value: RangeTo<f64>) -> Self {
-        HomiePropertyFormat::FloatRange(FloatRange {
-            min: None,
-            max: Some(value.end),
-            step: None,
-        })
-    }
-}
-
-impl From<RangeFrom<f64>> for HomiePropertyFormat {
-    fn from(value: RangeFrom<f64>) -> Self {
-        HomiePropertyFormat::FloatRange(FloatRange {
-            min: Some(value.start),
-            max: None,
-            step: None,
-        })
-    }
-}
-
 impl From<IntegerRange> for HomiePropertyFormat {
     fn from(value: IntegerRange) -> Self {
         HomiePropertyFormat::IntegerRange(value)
-    }
-}
-
-impl From<RangeInclusive<i64>> for HomiePropertyFormat {
-    fn from(value: RangeInclusive<i64>) -> Self {
-        HomiePropertyFormat::IntegerRange(IntegerRange {
-            min: Some(*value.start()),
-            max: Some(*value.end()),
-            step: None,
-        })
-    }
-}
-
-impl From<RangeTo<i64>> for HomiePropertyFormat {
-    fn from(value: RangeTo<i64>) -> Self {
-        HomiePropertyFormat::IntegerRange(IntegerRange {
-            min: None,
-            max: Some(value.end),
-            step: None,
-        })
-    }
-}
-
-impl From<RangeFrom<i64>> for HomiePropertyFormat {
-    fn from(value: RangeFrom<i64>) -> Self {
-        HomiePropertyFormat::IntegerRange(IntegerRange {
-            min: Some(value.start),
-            max: None,
-            step: None,
-        })
     }
 }
 


### PR DESCRIPTION
The recently changed builder API takes ranges that convert into these types, but currently the only conversions available are from themselves. Given that the `HomiePropertyFormat` isn't usable in the builder format anymore, I removed similar implementations for that type (and even if somebody is using these that away, they can get the same result with another `into()`.)