### PR TITLE
feat: custom HomieValue Deserialize accepting map and tag YAML forms

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -268,7 +268,7 @@ impl FromStr for HomieColorValue {
 ///
 /// The Homie protocol imposes specific rules on how these types should be represented in
 /// MQTT payloads, and this enum models those types.
-#[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize)]
 pub enum HomieValue {
     /// Represents an empty value, often used for uninitialized states.
     #[default]
@@ -326,7 +326,6 @@ pub enum HomieValue {
     /// - Must adhere to ISO 8601 format.
     ///
     /// Example: `2024-10-08T10:15:30Z`.
-    #[serde(deserialize_with = "deserialize_datetime")]
     DateTime(chrono::DateTime<chrono::Utc>),
 
     /// Represents a duration value.
@@ -334,7 +333,7 @@ pub enum HomieValue {
     /// - Must use ISO 8601 duration format (`PTxHxMxS`).
     ///
     /// Example: `"PT12H5M46S"` (12 hours, 5 minutes, 46 seconds).
-    #[serde(deserialize_with = "deserialize_duration", serialize_with = "serialize_duration")]
+    #[serde(serialize_with = "serialize_duration")]
     Duration(chrono::Duration),
 
     /// Represents a complex JSON object or array.
@@ -353,20 +352,135 @@ where
     serializer.serialize_str(&iso_str)
 }
 
-fn deserialize_duration<'de, D>(deserializer: D) -> Result<chrono::Duration, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s: &str = Deserialize::deserialize(deserializer)?;
-    HomieValue::parse_duration(s).map_err(de::Error::custom)
-}
+/// All `HomieValue` variant names, used for serde error reporting.
+const HOMIE_VALUE_VARIANTS: &[&str] = &[
+    "Empty", "String", "Integer", "Float", "Bool", "Enum", "Color", "DateTime", "Duration", "JSON",
+];
 
-fn deserialize_datetime<'de, D>(deserializer: D) -> Result<chrono::DateTime<chrono::Utc>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s: &str = Deserialize::deserialize(deserializer)?;
-    HomieValue::flexible_datetime_parser(s).map_err(de::Error::custom)
+/// Custom `Deserialize` implementation for [`HomieValue`].
+///
+/// A derived (externally tagged) implementation behaves inconsistently across serde's two
+/// deserialization paths in YAML:
+///
+/// - On the *direct* path, `serde_yaml`-family crates require the YAML tag form (`!Bool true`)
+///   for externally tagged enums and reject the single-key map form (`{ Bool: true }`).
+/// - On the *buffered* path (inside `#[serde(untagged)]`, `#[serde(tag = "...")]` or
+///   `#[serde(flatten)]` containers), only the single-key map form works, because serde's
+///   internal `Content` buffer cannot hold enum values.
+///
+/// This implementation accepts **both** representations wherever the format provides them, so
+/// the documented map form (which is also the JSON representation) parses in every context:
+///
+/// - the single-key map form: `{ Bool: true }`, `{ Integer: 5 }`, `{ Empty: null }`, ...
+/// - the enum/tag form where the format supports it: `!Bool true` (YAML direct path)
+/// - the bare string `"Empty"` for the unit variant
+///
+/// `DateTime` and `Duration` payloads are parsed from owned strings via
+/// [`HomieValue::flexible_datetime_parser`] and [`HomieValue::parse_duration`], which also
+/// avoids "expected borrowed string" failures inside buffered contexts.
+impl<'de> Deserialize<'de> for HomieValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct HomieValueVisitor;
+
+        impl<'de> de::Visitor<'de> for HomieValueVisitor {
+            type Value = HomieValue;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str(
+                    "a HomieValue: a single-key map like { Bool: true }, an externally tagged enum, or the string \"Empty\"",
+                )
+            }
+
+            // Unit variant as bare string: "Empty"
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if v == "Empty" {
+                    Ok(HomieValue::Empty)
+                } else {
+                    Err(de::Error::unknown_variant(v, HOMIE_VALUE_VARIANTS))
+                }
+            }
+
+            // Single-key map form: { Bool: true } — works on both direct and buffered paths.
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::MapAccess<'de>,
+            {
+                let Some(variant) = map.next_key::<String>()? else {
+                    return Err(de::Error::invalid_length(0, &"a map with exactly one HomieValue variant key"));
+                };
+                let value = match variant.as_str() {
+                    "Empty" => {
+                        map.next_value::<de::IgnoredAny>()?;
+                        HomieValue::Empty
+                    }
+                    "String" => HomieValue::String(map.next_value()?),
+                    "Integer" => HomieValue::Integer(map.next_value()?),
+                    "Float" => HomieValue::Float(map.next_value()?),
+                    "Bool" => HomieValue::Bool(map.next_value()?),
+                    "Enum" => HomieValue::Enum(map.next_value()?),
+                    "Color" => HomieValue::Color(map.next_value()?),
+                    "DateTime" => {
+                        let s: String = map.next_value()?;
+                        HomieValue::DateTime(HomieValue::flexible_datetime_parser(&s).map_err(de::Error::custom)?)
+                    }
+                    "Duration" => {
+                        let s: String = map.next_value()?;
+                        HomieValue::Duration(HomieValue::parse_duration(&s).map_err(de::Error::custom)?)
+                    }
+                    "JSON" => HomieValue::JSON(map.next_value()?),
+                    other => return Err(de::Error::unknown_variant(other, HOMIE_VALUE_VARIANTS)),
+                };
+                if map.next_key::<de::IgnoredAny>()?.is_some() {
+                    return Err(de::Error::custom("expected a map with exactly one HomieValue variant key"));
+                }
+                Ok(value)
+            }
+
+            // Enum/tag form: `!Bool true` on the serde_yaml direct path.
+            fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::EnumAccess<'de>,
+            {
+                use serde::de::VariantAccess;
+
+                let (variant, access) = data.variant::<String>()?;
+                match variant.as_str() {
+                    "Empty" => {
+                        access.unit_variant()?;
+                        Ok(HomieValue::Empty)
+                    }
+                    "String" => Ok(HomieValue::String(access.newtype_variant()?)),
+                    "Integer" => Ok(HomieValue::Integer(access.newtype_variant()?)),
+                    "Float" => Ok(HomieValue::Float(access.newtype_variant()?)),
+                    "Bool" => Ok(HomieValue::Bool(access.newtype_variant()?)),
+                    "Enum" => Ok(HomieValue::Enum(access.newtype_variant()?)),
+                    "Color" => Ok(HomieValue::Color(access.newtype_variant()?)),
+                    "DateTime" => {
+                        let s: String = access.newtype_variant()?;
+                        Ok(HomieValue::DateTime(
+                            HomieValue::flexible_datetime_parser(&s).map_err(de::Error::custom)?,
+                        ))
+                    }
+                    "Duration" => {
+                        let s: String = access.newtype_variant()?;
+                        Ok(HomieValue::Duration(
+                            HomieValue::parse_duration(&s).map_err(de::Error::custom)?,
+                        ))
+                    }
+                    "JSON" => Ok(HomieValue::JSON(access.newtype_variant()?)),
+                    other => Err(de::Error::unknown_variant(other, HOMIE_VALUE_VARIANTS)),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(HomieValueVisitor)
+    }
 }
 
 impl Display for HomieValue {

--- a/tests/homie_value_serde.rs
+++ b/tests/homie_value_serde.rs
@@ -1,0 +1,128 @@
+//! Serde (YAML/JSON) representation tests for `HomieValue`.
+//!
+//! `HomieValue` has a hand-written `Deserialize` impl that must accept the canonical
+//! single-key map form (`{ Bool: true }`) in EVERY context:
+//!
+//! - the *direct* path (a plain struct field deserialized by serde_yaml itself), where a
+//!   derived externally tagged enum would demand the `!Bool true` tag form, and
+//! - the *buffered* path (inside `#[serde(untagged)]` / `#[serde(tag = "...")]` /
+//!   `#[serde(flatten)]` containers), where serde's `Content` buffer only supports the map
+//!   form.
+//!
+//! The YAML tag form (`!Bool true`) additionally keeps working on the direct path.
+
+use homie5::{HomieColorValue, HomieValue};
+use serde::Deserialize;
+
+fn all_values() -> Vec<(&'static str, HomieValue)> {
+    vec![
+        ("{ String: hello }", HomieValue::String("hello".to_string())),
+        ("{ Integer: 5 }", HomieValue::Integer(5)),
+        ("{ Float: 5.5 }", HomieValue::Float(5.5)),
+        ("{ Bool: true }", HomieValue::Bool(true)),
+        ("{ Enum: low }", HomieValue::Enum("low".to_string())),
+        ("{ Color: 'rgb,255,0,0' }", HomieValue::Color(HomieColorValue::RGB(255, 0, 0))),
+        (
+            "{ DateTime: '2024-10-08T10:15:30Z' }",
+            HomieValue::DateTime(chrono::DateTime::parse_from_rfc3339("2024-10-08T10:15:30Z").unwrap().into()),
+        ),
+        (
+            "{ Duration: PT12H5M46S }",
+            HomieValue::Duration(chrono::Duration::seconds(12 * 3600 + 5 * 60 + 46)),
+        ),
+        (
+            r#"{ JSON: { temperature: 21.5 } }"#,
+            HomieValue::JSON(serde_json::json!({ "temperature": 21.5 })),
+        ),
+    ]
+}
+
+/// Direct path: the field is deserialized by serde_yaml itself.
+#[derive(Debug, Deserialize)]
+struct Direct {
+    value: HomieValue,
+}
+
+/// Buffered path: untagged enum forces serde to buffer through `Content`.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Buffered {
+    Value { value: HomieValue },
+}
+
+impl Buffered {
+    fn into_value(self) -> HomieValue {
+        match self {
+            Buffered::Value { value } => value,
+        }
+    }
+}
+
+#[test]
+fn map_form_parses_on_direct_path() {
+    for (yaml, expected) in all_values() {
+        let parsed: Direct = serde_yaml::from_str(&format!("value: {yaml}")).unwrap_or_else(|e| panic!("direct path failed for `{yaml}`: {e}"));
+        assert_eq!(parsed.value, expected, "direct path mismatch for `{yaml}`");
+    }
+}
+
+#[test]
+fn map_form_parses_on_buffered_path() {
+    for (yaml, expected) in all_values() {
+        let parsed: Buffered = serde_yaml::from_str(&format!("value: {yaml}")).unwrap_or_else(|e| panic!("buffered path failed for `{yaml}`: {e}"));
+        assert_eq!(parsed.into_value(), expected, "buffered path mismatch for `{yaml}`");
+    }
+}
+
+#[test]
+fn tag_form_still_parses_on_direct_path() {
+    let cases = [
+        ("!Bool true", HomieValue::Bool(true)),
+        ("!Integer 5", HomieValue::Integer(5)),
+        ("!String hello", HomieValue::String("hello".to_string())),
+        ("!Duration PT5S", HomieValue::Duration(chrono::Duration::seconds(5))),
+    ];
+    for (yaml, expected) in cases {
+        let parsed: Direct = serde_yaml::from_str(&format!("value: {yaml}")).unwrap_or_else(|e| panic!("tag form failed for `{yaml}`: {e}"));
+        assert_eq!(parsed.value, expected, "tag form mismatch for `{yaml}`");
+    }
+}
+
+#[test]
+fn empty_parses_as_bare_string_and_map_form() {
+    let direct: Direct = serde_yaml::from_str("value: Empty").unwrap();
+    assert_eq!(direct.value, HomieValue::Empty);
+
+    let buffered: Buffered = serde_yaml::from_str("value: Empty").unwrap();
+    assert_eq!(buffered.into_value(), HomieValue::Empty);
+
+    // JSON-style map form with null payload
+    let direct: Direct = serde_yaml::from_str("value: { Empty: null }").unwrap();
+    assert_eq!(direct.value, HomieValue::Empty);
+}
+
+#[test]
+fn json_round_trip_is_unchanged() {
+    for (_, value) in all_values() {
+        let json = serde_json::to_string(&value).unwrap();
+        let back: HomieValue = serde_json::from_str(&json).unwrap_or_else(|e| panic!("JSON round trip failed for {json}: {e}"));
+        assert_eq!(back, value, "JSON round trip mismatch for {json}");
+    }
+    // Unit variant serializes as the bare string "Empty"
+    assert_eq!(serde_json::to_string(&HomieValue::Empty).unwrap(), "\"Empty\"");
+    assert_eq!(serde_json::from_str::<HomieValue>("\"Empty\"").unwrap(), HomieValue::Empty);
+}
+
+#[test]
+fn unknown_variant_and_multi_key_maps_are_rejected() {
+    assert!(serde_yaml::from_str::<Direct>("value: { Boolean: true }").is_err());
+    assert!(serde_yaml::from_str::<Direct>("value: { Bool: true, Integer: 5 }").is_err());
+    assert!(serde_yaml::from_str::<Direct>("value: NotAVariant").is_err());
+}
+
+#[test]
+fn invalid_payloads_error_with_context() {
+    assert!(serde_yaml::from_str::<Direct>("value: { Duration: nonsense }").is_err());
+    assert!(serde_yaml::from_str::<Direct>("value: { DateTime: nonsense }").is_err());
+    assert!(serde_yaml::from_str::<Direct>("value: { Color: nonsense }").is_err());
+}


### PR DESCRIPTION
The derived externally tagged Deserialize behaved inconsistently in YAML: serde_yaml's direct path demanded the !Bool tag form, while Content-buffered paths (untagged/tagged/flattened containers) only accepted the single-key map form { Bool: true }. The hand-written impl accepts both wherever the format provides them, making the documented map form work in every context. DateTime/Duration payloads now parse from owned strings, fixing latent 'expected borrowed string' failures in buffered contexts. JSON representation and serialization are unchanged.